### PR TITLE
Prioritize lexicographic weights by spare capacity

### DIFF
--- a/orlab/docs/06-tank-utilization-c.md
+++ b/orlab/docs/06-tank-utilization-c.md
@@ -1,0 +1,63 @@
+# Tank Utilization – Lexicographic Packing Strategy
+
+## Motivation
+
+The formulation from `exercise6b.py` minimizes the *aggregate* stranded
+capacity across all touched tanks.  Once the solver decides which tanks must be
+used, that sum becomes fixed—the spare capacity of those tanks minus the total
+demand we assigned to them.  Different placements that leave the same total
+unused space (e.g., swapping two demands between the same pair of tanks) are
+therefore perfectly tied in the objective, so SCIP can legitimately return any
+of them.  Some of those tied placements leave a single tank “half full” while
+others pack one tank tight and keep the other nearly empty.  We prefer the
+latter because concentrating the leftover space improves future flexibility.
+
+## Lexicographic objective
+
+We can express the “pack one tank before opening the next” preference without
+leaving the MILP world by turning that tie into a lexicographic objective:
+
+1. Choose a deterministic priority order for the tanks.  The implementation
+   sorts tanks by their initial spare capacity (stable for ties) so that tighter
+   tanks receive priority and get packed first.
+2. Pre-compute a strictly decreasing sequence of weights `w_t` so that each
+   weight dominates the total possible contribution of all lower-priority
+   tanks.  A robust recipe is:
+
+   ```python
+   base = spare_capacity.sum() + 1
+   weights[t_rank] = base ** (n_tanks - 1 - rank)
+   ```
+
+   Because each stranded variable is bounded above by its spare capacity, the
+   weighted sum effectively minimizes the stranded volume tank-by-tank.
+3. Keep the original binary assignment variables, capacity constraints, and
+   linking constraints.  The objective becomes
+
+   ```
+   minimize  sum_t w_t * stranded_t + penalty * sum_t use_t
+   ```
+
+   All coefficients are constants, so the model remains linear and compatible
+   with SCIP.
+
+This trick makes the solver first minimize the leftover space in the highest
+priority tank.  Among those optima it minimizes the stranded capacity in the
+next tank, and so on.  In the motivating example the solver now prefers to pack
+the first tank with the larger demand (leaving it nearly full) before touching
+the second tank.
+
+## Implementation highlights
+
+`exercise6c.py` follows the same data pipeline as `exercise6b.py`:
+
+* The function `tank_solve_c` accepts a dataframe with tank states and a list of
+  demand volumes, builds the MILP, and returns the resulting allocation as a new
+  dataframe.
+* All feasibility constraints are unchanged.  The only difference is the new
+  weighted objective based on the spare-capacity priority order.
+* The small `tank_usage_penalty` term is kept to discourage opening extra tanks
+  when multiple assignments share the same lexicographic pattern.
+
+The approach keeps the model small, transparent, and linear while producing the
+desired “fill one tank first” behavior.

--- a/orlab/src/orlab/exercise6c.py
+++ b/orlab/src/orlab/exercise6c.py
@@ -1,0 +1,137 @@
+"""Lexicographic variant of the tank utilization solver."""
+
+from __future__ import annotations
+
+from typing import Sequence, Tuple
+
+import pandas as pd
+from ortools.linear_solver import pywraplp
+
+
+def tank_solve_c(
+    tanks_df: pd.DataFrame,
+    demands: Sequence[float],
+    *,
+    tank_usage_penalty: float = 1.0,
+) -> Tuple[bool, pd.DataFrame | None]:
+    """Assign demands to tanks while minimizing stranded capacity lexicographically.
+
+    Args:
+        tanks_df: DataFrame indexed by tank identifier with at least the columns
+            ``current_level`` and ``max_level``.  The index is preserved in the
+            output so callers can identify the placement for each tank.
+        demands: Non-negative demand volumes that must each be assigned to a
+            single tank.
+        tank_usage_penalty: Small positive weight that discourages touching
+            additional tanks.  The default ``1.0`` is tiny compared to the
+            stranded capacity units, but helps the solver break ties when
+            multiple lexicographically equivalent solutions exist.
+
+    Returns:
+        Tuple ``(ok, result_df)``.  ``ok`` is ``True`` if an optimal solution is
+        found.  ``result_df`` is ``None`` when the model is infeasible.
+    """
+
+    solver = pywraplp.Solver.CreateSolver("SCIP")
+    if solver is None:
+        raise RuntimeError("Unable to create OR-Tools SCIP solver instance.")
+
+    demands = list(demands)
+    if not demands:
+        # Nothing to place; the original dataframe is already optimal.
+        df = tanks_df.copy()
+        df["demands"] = [[] for _ in range(len(df))]
+        df["placed"] = 0.0
+        df["new_level"] = df["current_level"]
+        df["stranded"] = 0.0
+        return True, df
+
+    spare_capacity = (
+        tanks_df["max_level"].astype(float) - tanks_df["current_level"].astype(float)
+    )
+    if (spare_capacity < 0).any():
+        raise ValueError("Current level exceeds max level for at least one tank.")
+
+    tank_indices = list(tanks_df.index)
+    demand_indices = range(len(demands))
+
+    # Decision variables
+    assign = {}
+    for t in tank_indices:
+        for d in demand_indices:
+            assign[t, d] = solver.BoolVar(f"assign_{t}_{d}")
+
+    use_tank = {t: solver.BoolVar(f"use_{t}") for t in tank_indices}
+
+    stranded = {
+        t: solver.NumVar(0.0, float(spare_capacity.loc[t]), f"stranded_{t}")
+        for t in tank_indices
+    }
+
+    # Each demand is assigned exactly once.
+    for d in demand_indices:
+        solver.Add(
+            sum(assign[t, d] for t in tank_indices) == 1,
+            name=f"assign_once_{d}",
+        )
+
+    # Capacity and linking constraints per tank.
+    for t in tank_indices:
+        capacity_added = solver.Sum(demands[d] * assign[t, d] for d in demand_indices)
+        spare = float(spare_capacity.loc[t])
+
+        solver.Add(capacity_added <= spare, name=f"capacity_{t}")
+
+        # Activate use_tank whenever any demand is placed into tank t.
+        for d in demand_indices:
+            solver.Add(use_tank[t] >= assign[t, d], name=f"use_link_{t}_{d}")
+
+        big_m = spare
+        solver.Add(stranded[t] <= spare - capacity_added + big_m * (1 - use_tank[t]))
+        solver.Add(stranded[t] >= spare - capacity_added - big_m * (1 - use_tank[t]))
+        solver.Add(stranded[t] <= big_m * use_tank[t])
+
+    # Build lexicographic weights using a deterministic priority order.  We sort
+    # tanks by their *initial* spare capacity, so tighter tanks are optimized
+    # first.  This keeps the objective linear while nudging the solver to fill
+    # small holes before opening roomier ones.
+    priority_order = list(
+        spare_capacity.sort_values(kind="mergesort").index  # stable for ties
+    )
+
+    base = float(spare_capacity.sum()) + 1.0
+    weights: dict[int, float] = {}
+    for rank, t in enumerate(priority_order):
+        exponent = len(priority_order) - 1 - rank
+        weights[t] = base**exponent
+
+    objective = solver.Sum(weights[t] * stranded[t] for t in tank_indices)
+    objective += tank_usage_penalty * solver.Sum(use_tank.values())
+    solver.Minimize(objective)
+
+    status = solver.Solve()
+    ok = status == pywraplp.Solver.OPTIMAL
+    if not ok:
+        return False, None
+
+    result = tanks_df.copy()
+    placed_demands: list[list[float]] = []
+    stranded_values = []
+    placed_amounts = []
+
+    for t in tank_indices:
+        allocations: list[float] = []
+        for d in demand_indices:
+            if assign[t, d].solution_value() > 0.5:
+                allocations.append(float(demands[d]))
+        placed_volume = sum(allocations)
+        placed_demands.append(allocations)
+        placed_amounts.append(placed_volume)
+        stranded_values.append(stranded[t].solution_value())
+
+    result["demands"] = placed_demands
+    result["placed"] = placed_amounts
+    result["new_level"] = result["current_level"] + result["placed"]
+    result["stranded"] = stranded_values
+
+    return True, result


### PR DESCRIPTION
## Summary
- prioritize tighter tanks first by ordering the lexicographic weights using initial spare capacity
- document the spare-capacity priority choice and its impact on the weighted objective

## Testing
- python - <<'PY' (fails: ModuleNotFoundError: No module named 'pandas')

------
https://chatgpt.com/codex/tasks/task_e_68d6b46ce3f88324b9c949de41afc15f