### PR TITLE
refactor: drop postponed annotations in exercise6d

### DIFF
--- a/orlab/src/orlab/exercise6d.py
+++ b/orlab/src/orlab/exercise6d.py
@@ -14,10 +14,8 @@ run multiple demand scenarios in sequence when experimenting from the command
 line.
 """
 
-from __future__ import annotations
-
+from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
-from typing import Iterable, Sequence, Tuple
 
 import math
 import sys
@@ -81,7 +79,7 @@ def tank_solve_d(
     demands: Sequence[float],
     *,
     tank_usage_penalty: float = 1.0,
-) -> Tuple[bool, pd.DataFrame | None]:
+) -> tuple[bool, pd.DataFrame | None]:
     """Assign demands so that stranded capacity is lexicographically minimal.
 
     Compared to :func:`tank_solve_c`, this variant keeps each tank's stranded


### PR DESCRIPTION
## Summary
- remove the postponed annotations import in `exercise6d`
- switch the typing imports to use built-in generics compatible with Python 3.12

## Testing
- pytest tests/test_exercise6d.py

------
https://chatgpt.com/codex/tasks/task_e_68d822373a548324876df550d234c29b